### PR TITLE
Fix imports/print for Py3 compat

### DIFF
--- a/timbral_models/Timbral_Booming.py
+++ b/timbral_models/Timbral_Booming.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import numpy as np
 import soundfile as sf
-import timbral_util
+from . import timbral_util
 
 
 def boominess_calculate(loudspec):

--- a/timbral_models/Timbral_Brightness.py
+++ b/timbral_models/Timbral_Brightness.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import numpy as np
 import soundfile as sf
-import timbral_util
+from . import timbral_util
 from scipy.signal import spectrogram
 
 

--- a/timbral_models/Timbral_Depth.py
+++ b/timbral_models/Timbral_Depth.py
@@ -2,7 +2,6 @@ from __future__ import division
 import numpy as np
 import soundfile as sf
 from scipy.signal import spectrogram
-import pyfilterbank
 import essentia
 import essentia.standard as es
 from . import timbral_util

--- a/timbral_models/Timbral_Depth.py
+++ b/timbral_models/Timbral_Depth.py
@@ -5,7 +5,7 @@ from scipy.signal import spectrogram
 import pyfilterbank
 import essentia
 import essentia.standard as es
-import timbral_util
+from . import timbral_util
 import scipy.stats
 
 

--- a/timbral_models/Timbral_Hardness.py
+++ b/timbral_models/Timbral_Hardness.py
@@ -3,7 +3,7 @@ import numpy as np
 import librosa
 import soundfile as sf
 from scipy.signal import spectrogram
-import timbral_util
+from . import timbral_util
 
 
 def timbral_hardness(fname, dev_output=False, phase_correction=False, clip_output=False, max_attack_time=0.1,

--- a/timbral_models/Timbral_Roughness.py
+++ b/timbral_models/Timbral_Roughness.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import numpy as np
 import soundfile as sf
-import timbral_util
+from . import timbral_util
 
 
 def plomp(f1, f2):

--- a/timbral_models/Timbral_Sharpness.py
+++ b/timbral_models/Timbral_Sharpness.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import numpy as np
 import soundfile as sf
-import timbral_util
+from . import timbral_util
 
 
 def sharpness_Fastl(loudspec):

--- a/timbral_models/Timbral_Warmth.py
+++ b/timbral_models/Timbral_Warmth.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 import soundfile as sf
 from scipy.signal import spectrogram
-import timbral_util
+from . import timbral_util
 import scipy.stats
 from sklearn import linear_model
 

--- a/timbral_models/timbral_util.py
+++ b/timbral_models/timbral_util.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import librosa
 import soundfile as sf
@@ -500,7 +500,7 @@ def calculate_attack_time(envelope_samples, fs, calculate_attack_segment=True, t
             if (end_level - start_level) < 0.2 or (th_end_idx - th_start_idx) < 2:
                 # force calculation type to all
                 gradient_calulation_type = 'all'
-                print 'unable to calculate attack gradient with the \'mean\' method, reverting to \'all\' method.'
+                print('unable to calculate attack gradient with the \'mean\' method, reverting to \'all\' method.')
 
         if gradient_calulation_type == 'mean':
             # calculate the gradient based on the weighted mean of each attack

--- a/timbral_models/timbral_util.py
+++ b/timbral_models/timbral_util.py
@@ -5,7 +5,6 @@ import soundfile as sf
 from scipy.signal import butter, lfilter, spectrogram
 import matplotlib.pyplot as plt
 import essentia.standard as es
-import pyfilterbank
 from essentia import Pool, array
 import scipy.stats
 

--- a/timbral_models/timbral_util.py
+++ b/timbral_models/timbral_util.py
@@ -3,7 +3,6 @@ import numpy as np
 import librosa
 import soundfile as sf
 from scipy.signal import butter, lfilter, spectrogram
-import matplotlib.pyplot as plt
 import essentia.standard as es
 from essentia import Pool, array
 import scipy.stats


### PR DESCRIPTION
Some fixes for compatibility with Python3.
Also removed unneeded imports of `pyfilterbank` and `matplotlib`.

Comparison of analysis results with Python2/3 and two test files:

**File 1**

| Descriptor | Value py2 | Value py3 |
| --- | --- | --- |
| hardness | 73.5924908968 | 73.5924908968|
| brightness | 83.6140806608 | 83.6140806608 |
| depth | 7.12198777305 | 7.12198777305 |
| roughness | 4.93429311128 | 4.93429311128 |
| sharpness | 3.24552206178 | 3.24552206178 |
| warmth | -11.5366549746 | -11.5366549746 |
| booming | 0.470598664524 | 0.470598664524 |

**File 2**

| Descriptor | Value py2 | Value py3 |
| --- | --- | --- |
| hardness | 76.9671257334 | 76.9671257334 |
| brightness | 62.1083976964 | 62.1083976964 |
| depth | 24.0898714745 | 24.0898714745 |
| roughness | 10.5333541031 | 10.5333541031 |
| sharpness | 1.5856964301 | 1.5856964301 |
| warmth | 22.8231207834 | 22.8231207834 |
| booming | 1.51895268303 | 1.51895268303 |
