### PR TITLE
Update librosa calls to fix argument errors.

### DIFF
--- a/timbral_models/Timbral_Hardness.py
+++ b/timbral_models/Timbral_Hardness.py
@@ -85,7 +85,7 @@ def timbral_hardness(fname, fs=0, dev_output=False, phase_correction=False, clip
 
     # calculate the onsets
     original_onsets = timbral_util.calculate_onsets(audio_samples, envelope, fs, nperseg=nperseg)
-    onset_strength = librosa.onset.onset_strength(audio_samples, fs)
+    onset_strength = librosa.onset.onset_strength(y=audio_samples, sr=fs)
     # If onsets don't exist, set it to time zero
     if not original_onsets:
         original_onsets = [0]

--- a/timbral_models/timbral_util.py
+++ b/timbral_models/timbral_util.py
@@ -639,7 +639,7 @@ def calculate_onsets(audio_samples, envelope_samples, fs, look_back_time=20, hys
                                             value of [0] is also possible during normal opperation.
     """
     # get onsets with librosa estimation
-    onsets = librosa.onset.onset_detect(audio_samples, fs, backtrack=True, units='samples')
+    onsets = librosa.onset.onset_detect(y=audio_samples, sr=fs, backtrack=True, units='samples')
 
     # set values for return_loop method
     time_thresh = int(look_back_time * 0.001 * fs)  # 10 ms default look-back time, in samples
@@ -747,7 +747,7 @@ def calculate_onsets(audio_samples, envelope_samples, fs, look_back_time=20, hys
         thd_corrected_onsets = []
 
         # get the onset strength
-        onset_strength = librosa.onset.onset_strength(audio_samples, fs)
+        onset_strength = librosa.onset.onset_strength(y=audio_samples, sr=fs)
 
         strength_onset_times = np.array(np.array(corrected_onsets) / 512).astype('int')
         strength_onset_times.clip(min=0)


### PR DESCRIPTION
Currently the calls to `librosa` that handle onset detection breaks the `timbral_extractor(...)`. Explicitly passing arguments fixes the issue.