### PR TITLE
Release 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## AudioCommons Timbral Models
-The timbral models were devleoped by the [Institute of Sound Recording (IoSR)](http://www.iosr.uk/AudioCommons/) at the University of Surrey, and was completed as part of the [AudioCommons project](https://www.audiocommons.org).  
+The timbral models were devleoped by the [Institute of Sound Recording (IoSR)](http://www.iosr.uk/AudioCommons/) at the University of Surrey, and was completed as part of the [AudioCommons project](https://www.audiocommons.org).
 
-The current distribution contains python scripts for predicting eight timbral characteristics: *hardness*, *depth*, *brightness*, *roughness*, *warmth*, *sharpness*, *booming*, and *reverberation*.  
+The current distribution contains python scripts for predicting eight timbral characteristics: *hardness*, *depth*, *brightness*, *roughness*, *warmth*, *sharpness*, *booming*, and *reverberation*.
 
 More detailed explanations of how the models function can be found in Deliverable D5.8: Release of timbral characterisation tools for semantically annotating non-musical content, available: http://www.audiocommons.org/materials/
 
@@ -12,10 +12,10 @@ The timbral_models package can be installed using the pip command.  This will ha
 pip install timbral_models
 ```
 
-Please note that during testing, pip was unable to install some of the dependencies and produced an error.  In these cases, either rerun the `pip install timbral_models` command or install the offending dependency directly, e.g. `pip install numpy`. 
+Please note that during testing, pip was unable to install some of the dependencies and produced an error.  In these cases, either rerun the `pip install timbral_models` command or install the offending dependency directly, e.g. `pip install numpy`.
 
 The package can also be installed locally and be made editable.  To do this, clone the repository, navigate to the folder, and run the pip command `pip install -e .`.  In this method, dependencies will not be installed.
-  
+
 
 ## Dependencies
 The script can also be downloaded manually from the github repository (https://github.com/AudioCommons/timbral_models).  If doing this, dependencies will need to be manually installed.  The timbral models rely on several other easily accessible python packages: `numpy`, `soundfile`, `librosa`, `scikit-learn`, and `scipy`.  These are all easily installed using the `pip install` command.  e.g.
@@ -26,7 +26,7 @@ $ pip install librosa
 $ pip install scipy
 $ pip install scikit-learn
 $ pip install six
-$ pip install pyloudnorm   
+$ pip install pyloudnorm
 ```
 
 
@@ -40,7 +40,7 @@ import timbral_models
 fname = '/Documents/Music/TestAudio.wav'
 timbre = timbral_models.timbral_extractor(fname)
 ```
-In this example, `timbre` will be a python dictionary containing the predicted *hardness*, *depth*, *brightness*, *roughness*, *warmth*, *sharpness*, *booming*, and *reverberation* of the specified audio file.  
+In this example, `timbre` will be a python dictionary containing the predicted *hardness*, *depth*, *brightness*, *roughness*, *warmth*, *sharpness*, *booming*, and *reverberation* of the specified audio file.
 
 
 ### Single attribute calculation
@@ -55,11 +55,11 @@ timbre = timbral_models.timbral_hardness(fname)
 
 
 ## Model output
-The *hardness*, *depth*, *brightness*, *roughness*, *warmth*, *sharpness*, and *booming* are regression based models, trained on subjective ratings ranging from 0 to 100.  However, the output may be beyond these ranges.   
+The *hardness*, *depth*, *brightness*, *roughness*, *warmth*, *sharpness*, and *booming* are regression based models, trained on subjective ratings ranging from 0 to 100.  However, the output may be beyond these ranges.
 The `clip_output` optional parameter can be  used to contrain the outputs between 0 and 100.
 ```
 timbre = timbral_models.timbral_extractor(fname, clip_output=True)
-```   
+```
 For additional optional parameters, please see Deliverable D5.8.
 
 The *reverb* attribute is a classification model, returning 1 or 0, indicating if the file "sounds reverberant" or "does not sound reverberant" respectively.
@@ -71,15 +71,17 @@ Also contained in this repository is a full version of the timbral reverb model.
 ## Version History
 This section documents the version history of the timbral models.  To download a specific version of the model that relate to a specific deliverable, please check this section and download the most recent version from that date.
 
+2024/05/24 - Version 0.4.1 of timbral_models fixes a dependency with scikit_lern and introduces timbral_models.__version__
+
 2019/01/24 - Version 0.4 of timbral_models, relates to Audio Commons Deliverable D5.8.  This version of the repository relates to the software version 0.4 on PyPI.
 
 2018/12/14 - Version 0.3 of timbral models, relates to Audio Commons Deliverable D5.7. This version of the repository relates to the software version 0.3 on PyPI.
 
-2018/07/26 - Version 0.2 of timbral models, relates to Audio Commons Deliverable D5.6.  This version of the repository relates to the software version 0.2 on PyPI. 
+2018/07/26 - Version 0.2 of timbral models, relates to Audio Commons Deliverable D5.6.  This version of the repository relates to the software version 0.2 on PyPI.
 
 2017/09/05 - Version 0.1 of timbral models, relates to Audio Commons Deliverable D5.3.  This version of the repository relates to the software version 0.1 on PyPI.
 
-2017/04/27 - Version 0.0 of the timbral models, relates to Audio Commons Deliverable D5.2. 
+2017/04/27 - Version 0.0 of the timbral models, relates to Audio Commons Deliverable D5.2.
 
 
 ## Citation

--- a/Version history.md
+++ b/Version history.md
@@ -13,11 +13,13 @@ This is available: http://www.audiocommons.org/materials/
 
 ## Past versions
 
+2024/05/24 - Version 0.4.1 of timbral_models fixes a dependency with scikit_lern and introduces timbral_models.__version__
+
 2019/01/24 - Version 0.4 of timbral_models, relates to Audio Commons Deliverable D5.8.  This version of the repository relates to the software version 0.4 on PyPI.
 
 2018/12/14 - Version 0.3 of timbral models, relates to Audio Commons Deliverable D5.7. This version of the repository relates to the software version 0.3 on PyPI.
 
-2018/07/26 - Version 0.2 of timbral models, relates to Audio Commons Deliverable D5.6.  This version of the repository relates to the software version 0.2 on PyPI. 
+2018/07/26 - Version 0.2 of timbral models, relates to Audio Commons Deliverable D5.6.  This version of the repository relates to the software version 0.2 on PyPI.
 
 2017/09/05 - Version 0.1 of timbral models, relates to Audio Commons Deliverable D5.3.  This version of the repository relates to the software version 0.1 on PyPI.
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='timbral_models',
-      version='0.4.0',
+      version='0.4.1',
       description='Algorithms for predicting the timbral characteristics of audio files',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/timbral_models/__init__.py
+++ b/timbral_models/__init__.py
@@ -1,3 +1,5 @@
+__version__ = '0.4.1'
+
 from .Timbral_Brightness import timbral_brightness
 from .Timbral_Depth import timbral_depth
 from .Timbral_Hardness import timbral_hardness


### PR DESCRIPTION
@ffont I noted that there is no new release on pypi after the latest changes. Maybe this helps:

- update version to 0.4.1 in setup.py, readme, and history
- add `timbral_model.__version__` to be able to easily check version from within Python.

Let me know if there is anything I can help with.

ps. Sorry - there are some automatic changes such as removing trailing spaces done by my IDE that clutter the PR a bit.